### PR TITLE
clean up text

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,15 @@ async function lookup (query, locale = 'en') {
   const key = Object.keys(flat(body)).find(key => key.endsWith('.extract'))
   if (!key) return null // 404 word not found
   const html = getProp(body, key)
-  const text = cheerio.load(html).text().trim()
+  const text = cheerio.load(html).text()
+    .trim() // remove extra whitespace and newlines
+    .replace('English\n', '')
+    .replace('Noun\n', '')
+    .replace('Etymology\n', 'Etymology: ')
+    .replace('Translation\n', 'Translation: ')
+    .replace('Anagrams\n', 'Anagrams: ')
+    .replace(/\n+/gm, '\n') // duplicate newlines
+    .replace(/\n/gm, '; ')
   return {query, html, text}
 }
 

--- a/test.js
+++ b/test.js
@@ -10,8 +10,8 @@ test('happy path for a known word', async () => {
   expect(result.html.includes('<p>')).toBe(true)
   expect(result.text.includes('<p>')).toBe(false)
 
-  // trims newlines
-  expect(result.text).toMatch(/^English/)
+  // trims newlines and extra stuff
+  expect(result.text).toMatch(/^Etymology: From Latin/)
 })
 
 test('unhappy path with a nonexistent term', async () => {


### PR DESCRIPTION
Before

```
$ wiktionary acarology

English
Etymology
acaro- +‎ -logy

Noun
acarology (uncountable)
The study of ticks and mites.
2001: Acarology Bulletin aims at providing members of Systematic and Applied Acarology Society with information about mites and ticks and enhancing the communication among members. — Hu, Dr. Renjie and Zhang, Dr. Zhi-Qiang. Acarology Bulletin: The Newsletter of the Systematic and Applied Acarology Society. Retrieved 2005-03-20.
2003: The International Journal of Acarology publishes original research work on a wide variety of acarological subjects including mite and tick behavior, biochemistry, biology, control, ecology, evolution, morphology, physiology, systematics and taxonomy. — Scope note for the International Journal of Acarology. Retrieved 2005-03-20.

Translations

Anagrams
Cayo Largo
```

After

```
$ wiktionary acarology

Etymology: acaro- +‎ -logy; acarology (uncountable); The study of ticks and mites.; 2001: Acarology Bulletin aims at providing members of Systematic and Applied Acarology Society with information about mites and ticks and enhancing the communication among members. — Hu, Dr. Renjie and Zhang, Dr. Zhi-Qiang. Acarology Bulletin: The Newsletter of the Systematic and Applied Acarology Society. Retrieved 2005-03-20.; 2003: The International Journal of Acarology publishes original research work on a wide variety of acarological subjects including mite and tick behavior, biochemistry, biology, control, ecology, evolution, morphology, physiology, systematics and taxonomy. — Scope note for the International Journal of Acarology. Retrieved 2005-03-20.; Translations; Anagrams: Cayo Largo
```