### PR TITLE
fix: CORS support

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ async function lookup (query, locale = 'en') {
       action: 'query',
       format: 'json',
       prop: 'extracts',
+      origin: "*",
       titles: query
     }
   })


### PR DESCRIPTION
Added an origin=* parameter in URL to [enable CORS](https://github.com/words/wiktionary/issues/7)